### PR TITLE
Fixed error ouput when mixing sources with undeclared and UTF-8 encoding

### DIFF
--- a/mergexml.js
+++ b/mergexml.js
@@ -165,7 +165,9 @@
      */
     var CheckSource = function(doc) {
       var rlt = true;
-      if (doc.characterSet !== that.dom.characterSet) {
+      var charSet1 = that.dom.characterSet || that.dom.inputEncoding || that.dom.xmlEncoding;
+      var charSet2 = doc.characterSet || doc.inputEncoding || doc.xmlEncoding
+      if (charSet2 !== charSet1) {
         rlt = Error('enc');
       } else if (doc.documentElement.namespaceURI !== that.dom.documentElement.namespaceURI) { /* $dom->documentElement->lookupnamespaceURI(NULL) */
         rlt = Error('nse');
@@ -173,7 +175,7 @@
         if (!join[0]) {
           rlt = Error('dif');
         } else if (!join[1]) {
-          var enc = that.dom.characterSet ? that.dom.characterSet : 'UTF-8';
+          var enc = typeof charSet1 !== 'undefined' ? charSet1 : 'UTF-8';
           var ver = that.dom.xmlVersion ? that.dom.xmlVersion : '1.0';
           var xml = '<?xml version="' + ver + '" encoding="' + enc + "\"?>\r\n<" + join[0] + ">\r\n</" + join[0] + '>';
           var d = Load(xml);

--- a/mergexml.js
+++ b/mergexml.js
@@ -165,7 +165,7 @@
      */
     var CheckSource = function(doc) {
       var rlt = true;
-      if (doc.inputEncoding !== that.dom.inputEncoding || doc.xmlEncoding !== that.dom.xmlEncoding) {
+      if (doc.characterSet !== that.dom.characterSet) {
         rlt = Error('enc');
       } else if (doc.documentElement.namespaceURI !== that.dom.documentElement.namespaceURI) { /* $dom->documentElement->lookupnamespaceURI(NULL) */
         rlt = Error('nse');
@@ -173,8 +173,8 @@
         if (!join[0]) {
           rlt = Error('dif');
         } else if (!join[1]) {
-          var enc = that.dom.inputEncoding ? that.dom.inputEncoding : (that.dom.xmlEncoding ? that.dom.xmlEncoding : 'utf-8'),
-                  ver = that.dom.xmlVersion ? that.dom.xmlVersion : '1.0';
+          var enc = that.dom.characterSet ? that.dom.characterSet : 'UTF-8';
+          var ver = that.dom.xmlVersion ? that.dom.xmlVersion : '1.0';
           var xml = '<?xml version="' + ver + '" encoding="' + enc + "\"?>\r\n<" + join[0] + ">\r\n</" + join[0] + '>';
           var d = Load(xml);
           if (d) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mergexml",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Merge multiple XML sources",
   "main": "mergexml.js",
   "repository": {

--- a/test/spec/merge.spec.js
+++ b/test/spec/merge.spec.js
@@ -7,6 +7,7 @@ describe('Instantiating object ', function() {
 
     it('works', function() {
         merger = new MergeXML();
+
         expect(merger).to.be.an('object');
     });
 
@@ -19,6 +20,7 @@ describe('Adding source', function() {
         merger = new MergeXML();
         a = '<a/>';
         b = '<b/>';
+
         expect(merger.AddSource(a)).to.not.equal(false);
         expect(merger.AddSource(b)).to.not.equal(false);
     });
@@ -55,6 +57,7 @@ describe('Merging XML sources', function() {
             b = '<b/>';
             merger.AddSource(a);
             merger.AddSource(b);
+
             expect(merger.Get(1)).to.equal('<a/>');
         });
 
@@ -84,6 +87,7 @@ describe('Merging XML sources', function() {
             merger = new MergeXML();
             merger.AddSource(a);
             merger.AddSource(b);
+
             expect(merger.Get(1)).to.equal('<a><c>s1</c><c>s4</c><b>s2</b></a>');
         });
 
@@ -107,6 +111,7 @@ describe('Merging XML sources', function() {
                 '</a>';
             merger.AddSource(a);
             merger.AddSource(b);
+
             expect(merger.Get(1)).to.equal('<a><c>s1</c><c>s2</c><c>s4</c></a>');
         });
     });
@@ -127,11 +132,47 @@ describe('Merging XML sources', function() {
                 '</a>';
             merger.AddSource(a);
             merger.AddSource(b);
+
+            expect(merger.error.code).to.equal('');
+            expect(merger.error.text).to.equal('');
             expect(merger.Get(1)).to.equal('<a xmlns:enk="' + ns + '"><c enk:custom="something">s2</c></a>');
             expect(merger.Get(0).querySelector('c').attributes[0].localName).to.equal('custom');
             expect(merger.Get(0).querySelector('c').attributes[0].namespaceURI).to.equal(ns);
         })
 
     })
+
+    describe('with sources that have and do not have a UTF encoding declaration', function() {
+        var merger;
+        var a = '<?xml version="1.0"?>' +
+            '<a><c>s1</c></a>';
+        var b = '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<a><c>s2</c></a>';
+
+        it('undeclared and UTF-8', function() {
+            merger = new MergeXML({
+                join: false
+            });
+            merger.AddSource(a);
+            merger.AddSource(b);
+
+            expect(merger.error.code).to.equal('');
+            expect(merger.error.text).to.equal('');
+            expect(merger.Get(1)).to.contain('<a><c>s2</c></a>');
+        });
+
+        it('UTF8 and undeclared', function() {
+            merger = new MergeXML({
+                join: false
+            });
+            merger.AddSource(b);
+            merger.AddSource(a);
+
+            expect(merger.error.code).to.equal('');
+            expect(merger.error.text).to.equal('');
+            expect(merger.Get(1)).to.contain('<a><c>s1</c></a>');
+        });
+
+    });
 
 });


### PR DESCRIPTION
Hi Vallo,

When merging docs with a declared UTF-8 and an undeclared encoding, this library outputs an error.

This PR changes this behaviour by relying on the browser to determine the character set of the documents and only show an error when they are not the same.

It's using the (currently) recommended `document.characterSet` attribute instead of `inputEncoding` and `xmlEncoding`. I've tested this as far back as IE11 only and it's supported there.

I **hope** this has no side-effects. If you have any concerns, please let know. We could try to write a test for that case.