### PR TITLE
Fixed namespaced attributes exception in IE11 (and below probably).

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can get the XML result tree:
 
 The result object can be accessed also via *oMX.dom* property. The properties available:
 
-- **dom** - result XML DOM object
+- **dom** - result XML DOM object - **Note that in older IE browsers this is an ActiveX Object and not a standard XML Document!**
 - **nsp** - namespaces object (prefix:URI)
 - **count** - number of sources merged
 - **error** - error information

--- a/mergexml.js
+++ b/mergexml.js
@@ -196,7 +196,12 @@
         var a = NameSpaces(doc.documentElement);
         for (var c in a) {
           if (!that.nsp[c]) {
-            that.dom.documentElement.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:' + c, a[c]);
+            if (typeof that.dom.documentElement.setAttributeNS !== 'undefined') {
+              that.dom.documentElement.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:' + c, a[c]);
+            } else {
+              // no choice but to use the incorrect setAttribute instead
+              that.dom.documentElement.setAttribute('xmlns:' + c, a[c]);
+            }
             that.nsp[c] = a[c];
           }
         }
@@ -234,7 +239,7 @@
             if (flg) {
               try {
                 for (var j = 0; j < node.attributes.length; j++) { /* add/replace attributes */
-                  if (node.attributes[j].namespaceURI) {
+                  if (node.attributes[j].namespaceURI && typeof node.setAttributeNS !== 'undefined') {
                     obj.setAttributeNS(node.attributes[j].namespaceURI, node.attributes[j].nodeName, node.attributes[j].nodeValue);
                   } else {
                     obj.setAttribute(node.attributes[j].nodeName, node.attributes[j].nodeValue);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mergexml",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Merge multiple XML sources",
   "main": "mergexml.js",
   "repository": {

--- a/test/spec/merge.spec.js
+++ b/test/spec/merge.spec.js
@@ -46,7 +46,7 @@ describe('Merging XML sources', function() {
             b = '<r><b/></r>';
             merger.AddSource(a);
             merger.AddSource(b);
-            expect(merger.Get(1)).to.equal('<r><a/><b/></r>');
+            expect(merger.Get(1).trim()).to.equal('<r><a/><b/></r>');
         });
 
         it('fails to merge second source if sources do not have a common root name', function() {
@@ -58,7 +58,7 @@ describe('Merging XML sources', function() {
             merger.AddSource(a);
             merger.AddSource(b);
 
-            expect(merger.Get(1)).to.equal('<a/>');
+            expect(merger.Get(1).trim()).to.equal('<a/>');
         });
 
     });
@@ -82,13 +82,13 @@ describe('Merging XML sources', function() {
                 '</a>';
             merger.AddSource(a);
             merger.AddSource(b);
-            expect(merger.Get(1)).to.equal('<a><c>s1</c><c>s4</c><b>s2</b></a>');
+            expect(merger.Get(1).trim()).to.equal('<a><c>s1</c><c>s4</c><b>s2</b></a>');
 
             merger = new MergeXML();
             merger.AddSource(a);
             merger.AddSource(b);
 
-            expect(merger.Get(1)).to.equal('<a><c>s1</c><c>s4</c><b>s2</b></a>');
+            expect(merger.Get(1).trim()).to.equal('<a><c>s1</c><c>s4</c><b>s2</b></a>');
         });
 
     });
@@ -112,7 +112,7 @@ describe('Merging XML sources', function() {
             merger.AddSource(a);
             merger.AddSource(b);
 
-            expect(merger.Get(1)).to.equal('<a><c>s1</c><c>s2</c><c>s4</c></a>');
+            expect(merger.Get(1).trim()).to.equal('<a><c>s1</c><c>s2</c><c>s4</c></a>');
         });
     });
 
@@ -135,9 +135,10 @@ describe('Merging XML sources', function() {
 
             expect(merger.error.code).to.equal('');
             expect(merger.error.text).to.equal('');
-            expect(merger.Get(1)).to.equal('<a xmlns:enk="' + ns + '"><c enk:custom="something">s2</c></a>');
-            expect(merger.Get(0).querySelector('c').attributes[0].localName).to.equal('custom');
-            expect(merger.Get(0).querySelector('c').attributes[0].namespaceURI).to.equal(ns);
+            expect(merger.Get(1).trim()).to.equal('<a xmlns:enk="' + ns + '"><c enk:custom="something">s2</c></a>');
+            // in IE11 and below, merger.Get(0) returns an ActiveXObject we use the internal "Query" function
+            expect(merger.Query('//c').attributes[0].localName).to.equal('custom'); // fails in IE because
+            expect(merger.Query('//c').attributes[0].namespaceURI).to.equal(ns);
         })
 
     })


### PR DESCRIPTION
The exception is fixed, but namespaced attributes in IE (and below) are now added in the old incorrect way.

I think there is a way to properly add namespaced attributes to ActiveXObjects but that seemed rather cumbersome to find out. While Internet Explorer is still alive I'll just re-parse the .Get(1) XML string in my app (because IE11 does actually have a DOMParser). (Alternatively you could decide to let .Get(0) do this if `GetMode() === 2 && typeof window.DOMParser !== 'undefined'`)

Also made tests more IE11 friendly as .Get(1) returns some additional whitespace in IE11.

Last PR for a while, I hope!

I took the liberty of changing the version to 1.1.2 as well.